### PR TITLE
MNT: special env is no longer required

### DIFF
--- a/add_routes.sh
+++ b/add_routes.sh
@@ -29,7 +29,6 @@ for ioc_host in $IOC_HOSTS; do
 
     ssh $ioc_host <<EOF
         source /reg/g/pcds/pyps/conda/pcds_conda
-        conda activate /cds/home/k/klauer/miniforge3/envs/py38
         set -x
         for plc in $PLCS; do
             ads-async route --route-name="${ioc_host}" \${plc} ${ioc_host_net_id} ${ioc_host_ip};


### PR DESCRIPTION
Closes #1 

New environment is in; hotfix for ads-async is no longer necessary.