### PR TITLE
Added ioc-cxi-mot2 to help with fms plc

### DIFF
--- a/ioc_hosts/cxi.txt
+++ b/ioc_hosts/cxi.txt
@@ -1,0 +1,1 @@
+ioc-cxi-mot2


### PR DESCRIPTION
Added ioc-cxi-mot2 to help with fms plc. **Other hosts might need to be added in the future, this list is not exhaustive**